### PR TITLE
Replaced args.kineto args.autograd_profiler to fix ddp bugs

### DIFF
--- a/micro_benchmarking_pytorch.py
+++ b/micro_benchmarking_pytorch.py
@@ -145,7 +145,7 @@ def rendezvous(distributed_parameters):
     torch.distributed.init_process_group(backend=distributed_parameters['dist_backend'], init_method=distributed_parameters['dist_url'], rank=distributed_parameters['rank'], world_size=distributed_parameters['world_size'])
     print("Rendezvous complete. Created process group...")
 
-def run_benchmarking_wrapper(net, batch_size, iterations, flops_prof_step, amp_opt_level, run_fp16, dataparallel, distributed_dataparallel, device_ids=None, distributed_parameters=None):
+def run_benchmarking_wrapper(net, batch_size, iterations, flops_prof_step, amp_opt_level, run_fp16, kineto, autograd_profiler, dataparallel, distributed_dataparallel, device_ids=None, distributed_parameters=None):
     if (dataparallel or distributed_dataparallel):
         ngpus = len(device_ids) if device_ids else torch.cuda.device_count()
     else:
@@ -155,11 +155,11 @@ def run_benchmarking_wrapper(net, batch_size, iterations, flops_prof_step, amp_o
         # Assumption below that each process launched with --distributed_dataparallel has the same number of devices visible/specified
         distributed_parameters['world_size'] = ngpus * distributed_parameters['world_size']
         distributed_parameters['rank'] = ngpus * distributed_parameters['rank']
-        mp.spawn(run_benchmarking, nprocs=ngpus, args=(ngpus, net, batch_size, iterations, flops_prof_step, amp_opt_level, run_fp16, dataparallel, distributed_dataparallel, device_ids, distributed_parameters))
+        mp.spawn(run_benchmarking, nprocs=ngpus, args=(ngpus, net, batch_size, iterations, flops_prof_step, amp_opt_level, run_fp16, kineto, autograd_profiler, dataparallel, distributed_dataparallel, device_ids, distributed_parameters))
     else:
-        run_benchmarking(0, ngpus, net, batch_size, iterations, flops_prof_step, amp_opt_level, run_fp16, dataparallel, distributed_dataparallel, device_ids=None, distributed_parameters=None)
+        run_benchmarking(0, ngpus, net, batch_size, iterations, flops_prof_step, amp_opt_level, run_fp16, kineto, autograd_profiler, dataparallel, distributed_dataparallel, device_ids=None, distributed_parameters=None)
 
-def run_benchmarking(local_rank, ngpus, net, batch_size, iterations, flops_prof_step, amp_opt_level, run_fp16, dataparallel, distributed_dataparallel, device_ids=None, distributed_parameters=None):
+def run_benchmarking(local_rank, ngpus, net, batch_size, iterations, flops_prof_step, amp_opt_level, run_fp16, kineto, autograd_profiler, dataparallel, distributed_dataparallel, device_ids=None, distributed_parameters=None):
     if device_ids:
         assert ngpus == len(device_ids)
         torch.cuda.set_device("cuda:%d" % device_ids[local_rank])
@@ -215,7 +215,7 @@ def run_benchmarking(local_rank, ngpus, net, batch_size, iterations, flops_prof_
 
     ## benchmark.
     print ("INFO: running the benchmark..")
-    if args.kineto:
+    if kineto:
         from torch.profiler import schedule, profile, ProfilerActivity, record_function
         profiler_schedule = schedule(
             skip_first = 0,
@@ -242,7 +242,7 @@ def run_benchmarking(local_rank, ngpus, net, batch_size, iterations, flops_prof_
             print(prof.key_averages().table(sort_by="cuda_time_total"))
     else:
         tm = time.time()
-        with torch.autograd.profiler.emit_nvtx(enabled=args.autograd_profiler):
+        with torch.autograd.profiler.emit_nvtx(enabled=autograd_profiler):
             for i in range(iterations):
                 if i == flops_prof_step:
                     forwardbackward(inp, optimizer, network, target, amp_opt_level, i)
@@ -298,6 +298,8 @@ def main():
     flops_prof_step = max(0, min(flops_prof_step, iterations - 1))
     run_fp16 = args.fp16
     amp_opt_level = args.amp_opt_level
+    kineto = args.kineto
+    autograd_profiler = args.autograd_profiler
     dataparallel = args.dataparallel
     distributed_dataparallel = args.distributed_dataparallel
     device_ids_str = args.device_ids
@@ -317,7 +319,7 @@ def main():
                args.dist_backend is not None and \
                args.dist_url is not None, "rank, world-size, dist-backend and dist-url are required arguments for distributed_dataparallel"
 
-    run_benchmarking_wrapper(net, batch_size, iterations, flops_prof_step, amp_opt_level, run_fp16, dataparallel, distributed_dataparallel, device_ids, distributed_parameters)
+    run_benchmarking_wrapper(net, batch_size, iterations, flops_prof_step, amp_opt_level, run_fp16, kineto, autograd_profiler, dataparallel, distributed_dataparallel, device_ids, distributed_parameters)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Fixed issue with args for distributed data parallel by including kineto and autograd_profiler as arguments: https://ontrack-internal.amd.com/browse/SWDEV-342779

Alternatively we could rename args to get around this issue, what do you think @jithunnair-amd 