### PR TITLE
Pass args object into run_benchmarking

### DIFF
--- a/micro_benchmarking_pytorch.py
+++ b/micro_benchmarking_pytorch.py
@@ -166,9 +166,9 @@ def run_benchmarking_wrapper(params):
                params.dist_url is not None, "rank, world-size, dist-backend and dist-url are required arguments for distributed_dataparallel"
     
     if (params.dataparallel or params.distributed_dataparallel):
-        vars(params)['ngpus'] = len(params.device_ids) if params.device_ids else torch.cuda.device_count()
+        params.ngpus = len(params.device_ids) if params.device_ids else torch.cuda.device_count()
     else:
-        vars(params)['ngpus'] = 1
+        params.ngpus = 1
 
     if (params.distributed_dataparallel):
         # Assumption below that each process launched with --distributed_dataparallel has the same number of devices visible/specified


### PR DESCRIPTION
Pass the args object into run_benchmarking to avoid the growing argument list.

Leaving as draft for now to get comments:
@jithunnair-amd 
Do you see any potential future issues with args being updated (maybe some potential post processing/analysis on the original args?)  for example in line 294
args.flops_prof_step = max(0, min(args.flops_prof_step, args.iterations - 1))

Or in run benchmark args.batch_size would now be updated:
args.batch_size = int(args.batch_size / ngpus)

